### PR TITLE
fix: correct tetris block sphere array (O_sphs→L_sphs)

### DIFF
--- a/spasm/tetris_env.py
+++ b/spasm/tetris_env.py
@@ -182,7 +182,7 @@ class Simulation:
         assert jnp.isclose(L_block_z, O_block_z).all(), "Block z offsets should be the same."
         self.block_z = L_block_z # Global Z to grasp blocks
 
-        all_block_spheres = [O_sphs, L_sphs, O_sphs, O_sphs, O_sphs,
+        all_block_spheres = [O_sphs, L_sphs, L_sphs, L_sphs, O_sphs,
                              L_sphs, L_sphs, L_sphs] #, L_sphs, L_sphs]
         # self.block_colors = [[255, 255, 186], [255, 186, 201], [186, 201, 255], [186, 255, 201], [102, 186, 232],
         #                      [255, 255, 186], [255, 186, 201], [186, 201, 255],]


### PR DESCRIPTION
## Summary
Corrects the tetris block sphere array to use L_sphs instead of O_sphs for the correct block types.

## Changes
- spasm/tetris_env.py: Changed O_sphs entries to L_sphs in all_block_spheres array

## Compliance
- commit_email: 166608075+Jah-yee@users.noreply.github.com
- 1 commit only